### PR TITLE
Use a more simple, standard, cache mechanism for slow api call actions.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,10 +93,12 @@ gem 'jbuilder'
 gem 'rest-client'
 gem 'hassle3'
 gem 'kgio'
-gem 'dalli'
 gem 'tzinfo'
 gem 'unicorn'
 gem 'backports'
+
+# For old-style action_caching
+gem "actionpack-action_caching"
 
 ######################################################################
 # 4/24/2013: The following was created by "rails new" command.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
       erubis (~> 2.7.0)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
+    actionpack-action_caching (1.0.0)
+      actionpack (>= 4.0.0.beta, < 5.0)
     activemodel (4.0.0.rc1)
       activesupport (= 4.0.0.rc1)
       builder (~> 3.1.0)
@@ -107,7 +109,6 @@ GEM
       diff-lcs (>= 1.1.3)
       gherkin (~> 2.12.0)
       multi_json (~> 1.3)
-    dalli (2.6.4)
     database_cleaner (1.0.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.4)
@@ -138,6 +139,7 @@ GEM
     fssm (0.2.10)
     gherkin (2.12.0)
       multi_json (~> 1.3)
+    growl (1.0.3)
     guard (1.8.0)
       formatador (>= 0.2.4)
       listen (>= 1.0.0)
@@ -175,8 +177,6 @@ GEM
     kgio (2.8.0)
     launchy (2.3.0)
       addressable (~> 2.3)
-    libnotify (0.8.0)
-      ffi (>= 1.0.11)
     libv8 (3.11.8.17)
     listen (1.1.6)
       rb-fsevent (>= 0.9.3)
@@ -325,6 +325,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  actionpack-action_caching
   autotest-fsevent
   autotest-growl
   autotest-rails
@@ -338,12 +339,12 @@ DEPENDENCIES
   coffee-rails
   compass-rails
   cucumber-rails!
-  dalli
   database_cleaner
   dotenv-rails
   email_spec
   execjs
   factory_girl_rails
+  growl
   guard
   guard-livereload
   haml
@@ -354,7 +355,6 @@ DEPENDENCIES
   kgio
   launchy
   letter_opener!
-  libnotify
   octokit
   omniauth
   omniauth-github

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,5 +1,8 @@
 class ContentController < ApplicationController
 
+  caches_action :meetings, expires_in: 2.hours
+  caches_action :videos,   expires_in: 1.day
+
   def index
 
   end

--- a/app/models/blip_video.rb
+++ b/app/models/blip_video.rb
@@ -1,11 +1,9 @@
 require 'rest_client'
-require 'cacheable'
 
 class BlipVideo
-  include Cacheable
 
   def self.all
-    result = memcached('blip-all') do
+    result = begin
      RestClient.get 'http://blip.tv/posts/?user=skiptree&skin=json&pagelen=5'
     end
     result.sub!("blip_ws_results([[{", "[{")

--- a/app/models/meetup_event.rb
+++ b/app/models/meetup_event.rb
@@ -1,11 +1,10 @@
 require 'rest_client'
-require 'cacheable'
 
 class MeetupEvent
-  include Cacheable
+
   def self.get_next_month_events
     itime = Time.now.to_i
-    result = memcached('MEETUP_KEY') do
+    result = begin
       RestClient.get "https://api.meetup.com/2/events?key" +
         "=#{ApiCredentials.key('MEETUP_KEY')}&
         sign=true&

--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -1,9 +1,0 @@
-module Cacheable
-  extend ActiveSupport::Concern
-  included do
-    def self.memcached(key)
-        cache_key = Digest::MD5.hexdigest("#{key}-#{Rails.env}")
-        yield
-    end
-  end
-end


### PR DESCRIPTION
Replaced ad hoc caching system with actionpack-action_caching. Will work about as well, and is better documented and more flexible. Also, does not require memcached.

Default caching will write to disk. For this site, this will probably be fine forever, but it can be changed to memcache et al later.
