### PR TITLE
Fixes tests for Rails 4.0.1

### DIFF
--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -18,33 +18,33 @@ describe SessionsController do
     it 'attempts to find a user by auth hash' do
       SessionsController.any_instance.stub(:auth_hash => auth_hash)
       User.should_receive(:find_by_hash).with(auth_hash).and_return(user)
-      post :create
+      post :create, :provider => 'github'
     end
 
     it 'creates a user by auth hash if one is not found' do
       SessionsController.any_instance.stub(:auth_hash => auth_hash)
       User.stub(:find_by_hash => nil)
       User.should_receive(:create_from_hash).with(auth_hash).and_return(user)
-      post :create
+      post :create, :provider => 'github'
     end
 
     it "logs the user in if they're an organizer" do
       user.stub(:atlrug_organizer? => true)
       User.stub(:find_by_hash => user)
-      post :create
+      post :create, :provider => 'github'
       session[:user_id].should == user.id
     end
 
     it "doesn't log the user in if they're not an organizer" do
       user.stub(:atlrug_organizer? => false)
       User.stub(:find_by_hash => user)
-      post :create
+      post :create, :provider => 'github'
       session[:user_id].should be_nil
     end
 
     it 'redirects to root' do
       User.stub(:find_by_hash => user)
-      post :create
+      post :create, :provider => 'github'
       response.should redirect_to root_url
     end
   end


### PR DESCRIPTION
Technically the route always required a `:provider` component; apparently
Rails 4.0.1 now blows up without it.

Fixes #39
