### PR TITLE
#42: Fix incompatible mixin in navigation CSS

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -14,3 +14,4 @@
 @import "components/footer";
 @import "components/banner";
 @import "components/forms";
+@import "components/navigation";

--- a/app/assets/stylesheets/components/navigation.css.scss
+++ b/app/assets/stylesheets/components/navigation.css.scss
@@ -2,8 +2,8 @@
 	a 								{  display: block; text-align: center;  }
 }
 a.btn.btn-navbar					{  background-image: none; background-color: darken($tan, 30%); border-color: darken($tan, 35%);}
-.navbar-inner 						{  position: relative; z-index: 50; border-bottom: 1px solid #c8c2b5; @include border-radius(0); background-image: none; background-color: $tan; @include box-shadow(rgba(#000, 0.02) 0 15px 3px);  }
-.logo 								{  position: absolute; @include box-shadow(rgba(#000, 0.02) 0 15px 3px);background-color: $tan; @include border-radius(1000px); padding: 0px;  position: absolute; top: 3px; left: 45%; z-index: 100; }
+.navbar-inner 						{  position: relative; z-index: 50; border-bottom: 1px solid #c8c2b5; background-image: none; background-color: $tan; @include box-shadow(rgba(#000, 0.02) 0 15px 3px);  }
+.logo 								{  position: absolute; @include box-shadow(rgba(#000, 0.02) 0 15px 3px);background-color: $tan; padding: 0px;  position: absolute; top: 3px; left: 45%; z-index: 100; }
 .nav>li>a 							{  line-height: 1em; padding: 10px; margin-top: 1.5em; margin-bottom: 1.5em; margin-left: 0.25em; margin-right: 0.25em;  }
 .nav-links  						{
 	a 								{  color: $gray; font-size: 1.2em; border-bottom: 2px solid $tan;


### PR DESCRIPTION
`border-radius` mixin is no longer supported by Bootstrap as of
[TWBS Pull 6342](https://github.com/twbs/bootstrap/pull/6342):

> Remove .border-radius() and .border-radius mixins. As only Android
> 2.1, iOS 3.2, and older desktop browsers require a prefixed version,
> we've removed the base mixin. Since we no longer require prefixes for
> independent corners, we've dropped those mixins as well. Mixins for a
> single side, like .border-left-radius, are still available.

So I just deleted the references in components/navigations.css.scss and
added that file back to the import list in application.css.scss
